### PR TITLE
Update lvl-drag-drop.js

### DIFF
--- a/script/lvl-drag-drop.js
+++ b/script/lvl-drag-drop.js
@@ -65,8 +65,8 @@ module.directive('lvlDropTarget', ['$rootScope', 'uuid', function($rootScope, uu
 	                e.stopPropagation(); // Necessary. Allows us to drop.
 	              }
 	            	var data = e.dataTransfer.getData("text");
-	                var dest = document.getElementById(id);
-	                var src = document.getElementById(data);
+	                var dest = id;
+	                var src = data;
 	                
 	                scope.onDrop({dragEl: src, dropEl: dest});
 	            });


### PR DESCRIPTION
Returning the DOM elements themselves causes a $parse:isecdom error in newer versions of AngularJS. Simply enough, let the `dropped(...)` callback handle fetching the elements.

See: https://github.com/logicbomb/lvlDragDrop/issues/14