### PR TITLE
Add "originalEvent" because the "jQuery event object" does not have a dataTransfer property.

### DIFF
--- a/script/lvl-drag-drop.js
+++ b/script/lvl-drag-drop.js
@@ -13,7 +13,7 @@ module.directive('lvlDraggable', ['$rootScope', 'uuid', function($rootScope, uui
 	            }
 	            
 	            el.bind("dragstart", function(e) {
-	                e.dataTransfer.setData('text', id);
+	                e.originalEvent.dataTransfer.setData('text', id);
 
 	                $rootScope.$emit("LVL-DRAG-START");
 	            });
@@ -43,7 +43,7 @@ module.directive('lvlDropTarget', ['$rootScope', 'uuid', function($rootScope, uu
 	                e.preventDefault(); // Necessary. Allows us to drop.
 	              }
 	              
-	              e.dataTransfer.dropEffect = 'move';  // See the section on the DataTransfer object.
+	              e.originalEvent.dataTransfer.dropEffect = 'move';  // See the section on the DataTransfer object.
 	              return false;
 	            });
 	            
@@ -64,9 +64,9 @@ module.directive('lvlDropTarget', ['$rootScope', 'uuid', function($rootScope, uu
 	              if (e.stopPropagation) {
 	                e.stopPropagation(); // Necessary. Allows us to drop.
 	              }
-	            	var data = e.dataTransfer.getData("text");
-	                var dest = document.getElementById(id);
-	                var src = document.getElementById(data);
+	            	var data = e.originalEvent.dataTransfer.getData("text");
+	                var dest = id;
+	                var src = data;
 	                
 	                scope.onDrop({dragEl: src, dropEl: dest});
 	            });


### PR DESCRIPTION
Please see this link for more information:
http://stackoverflow.com/questions/9566322/bind-native-html5-dragstart-event-handler-and-access-datatransfer-using-jquery